### PR TITLE
fix for free() of unused bdgreq

### DIFF
--- a/bdgfn/bdgfnctl.c
+++ b/bdgfn/bdgfnctl.c
@@ -136,14 +136,14 @@ int main(int argc, char **argv)
             continue;
 
 		bdgfninit();
-		ret = p->fn( parse_options(--argc, ++argv) );
+		ret = p->fn( (breq = parse_options(--argc, ++argv)) );
 		fprintf(stderr, "[%s]\n", ret ? "\033[31mnoterror\033[0m" : "\033[32mok\033[0m");
 		bdgfnfini();
+		free(breq);
     }
 
 	if (ret < 0) 
 		fprintf(stderr, "unknown command %s\n", *argv);
 
-	free(breq);
 	return 0;
 }


### PR DESCRIPTION
A little thing, but that free() led to a crash on my machine as follows:
**\* glibc detected **\* ./bdgfnctl: double free or corruption (out): 0x00000000004009d0 ***
