### PR TITLE
Makefile: misc fix for changing across directories in get-drivers

### DIFF
--- a/LINUX/Makefile
+++ b/LINUX/Makefile
@@ -57,8 +57,7 @@ get-drivers:
 	(cd .. ; \
 	for i in $(PATCHES) ; \
 	do patch -p1 < LINUX/patches/$$i; \
-	done ; );
-	cd -;
+	done ; cd -);
 
 
 prepare: get-drivers


### PR DESCRIPTION
For dash, it's fine to return back to OLDPWD out of scope, but for bash,
OLDPWD seems to be lost outside parenthesis.
